### PR TITLE
Fix sidePanel.open usage

### DIFF
--- a/quotes.js
+++ b/quotes.js
@@ -429,12 +429,18 @@ async function setupAIModels() {
       return session;
 }
 
-chrome.tabs.onCreated.addListener(() => {
-  chrome.sidePanel.open().then(() => {
-    console.log('Side panel opened successfully');
-  }).catch((err) => {
-    console.error('Error opening side panel:', err);
-  });
+chrome.tabs.onCreated.addListener((tab) => {
+  // chrome.sidePanel.open requires the tabId of the tab where the side panel
+  // should appear. Pass the newly created tab's id to avoid the
+  // "No matching signature" error.
+  chrome.sidePanel
+    .open({ tabId: tab.id })
+    .then(() => {
+      console.log('Side panel opened successfully');
+    })
+    .catch((err) => {
+      console.error('Error opening side panel:', err);
+    });
 });
 
 


### PR DESCRIPTION
## Summary
- pass the tab ID when calling `chrome.sidePanel.open`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686749593bec8326a6119971581457c2